### PR TITLE
Cleanup the Redis Pool when a RegionFactory is stopped. 

### DIFF
--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/AbstractRedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/AbstractRedisRegionFactory.java
@@ -66,6 +66,10 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
      * JedisClient instance.
      */
     protected JedisClient redis = null;
+
+    /**
+     * JedisCacheTimestamper instance.
+     */
     protected JedisCacheTimestamper timestamper = null;
 
     /**
@@ -176,6 +180,21 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
                                          regionName,
                                          properties,
                                          timestamper);
+    }
+
+    /**
+     * Cleanup any resources that the regionFactory might have references to.
+     */
+    protected void destroy() {
+        if (expirationThread != null) {
+            expirationThread.interrupt();
+            expirationThread = null;
+        }
+        if (redis != null) {
+            redis.destroy();
+            redis = null;
+        }
+        timestamper = null;
     }
 
     protected synchronized void startExpirationThread(final JedisClient redis) {

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/RedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/RedisRegionFactory.java
@@ -59,11 +59,7 @@ public class RedisRegionFactory extends AbstractRedisRegionFactory {
         log.debug("Stopping RedisRegionFactory...");
 
         try {
-            if (expirationThread != null) {
-                expirationThread.interrupt();
-                expirationThread = null;
-            }
-            redis = null;
+            destroy();
             log.info("RedisRegionFactory is stopped.");
         } catch (Exception e) {
             log.error("Failed to stop RedisRegionFactory.", e);

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/SingletonRedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/SingletonRedisRegionFactory.java
@@ -61,10 +61,7 @@ public class SingletonRedisRegionFactory extends AbstractRedisRegionFactory {
 
         if (ReferenceCount.decrementAndGet() == 0) {
             try {
-                redis = null;
-                if (expirationThread != null) {
-                    expirationThread.interrupt();
-                }
+                destroy();
                 log.info("Stopped SingletonRedisRegionFactory");
             } catch (Exception ignored) { }
         }

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/jedis/JedisClient.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/jedis/JedisClient.java
@@ -72,7 +72,7 @@ public class JedisClient {
      * @param jedisPool       JedisPool instance
      * @param expiryInSeconds expiration in seconds
      */
-    public JedisClient(Pool<Jedis>  jedisPool, int expiryInSeconds) {
+    public JedisClient(Pool<Jedis> jedisPool, int expiryInSeconds) {
         log.debug("JedisClient created. jedisPool=[{}], expiryInSeconds=[{}]", jedisPool, expiryInSeconds);
 
         this.jedisPool = jedisPool;
@@ -484,6 +484,15 @@ public class JedisClient {
             Long incrementedTimestamp = incrementTimestamp(rawKey);
             log.warn("updated timestamp failed {} times. Fall back to incrementing: key=[{}], timestamp=[{}]", updateAttempts, key, incrementedTimestamp);
             return incrementedTimestamp;
+        }
+    }
+
+    /**
+     * Cleanup any resources thathe JedisClient might have references to.
+     */
+    public void destroy() {
+        if (jedisPool != null) {
+            jedisPool.destroy();
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/debop/hibernate-redis/issues/29.
