### PR TITLE
Region factories cannot be configured.

### DIFF
--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/AbstractRedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/AbstractRedisRegionFactory.java
@@ -42,18 +42,11 @@ import java.util.concurrent.ConcurrentSkipListSet;
 abstract class AbstractRedisRegionFactory implements RegionFactory {
 
     /**
-     * The Hibernate system property specifying the location of the redis configuration file name.
-     * If not set, redis.xml will be looked for in the root of the classpath.
-     * If set to say redis-1.xml, redis-1.xml will be looked for in the root of the classpath.
-     */
-    public static final String IO_REDIS_CACHE_CONFIGURATION_RESOURCE_NAME = "io.redis.cache.configurationResourceName";
-
-    /**
      * Settings object for the Hibernate persistence unit.
      */
     protected Settings settings;
 
-    protected Properties props;
+    protected Properties properties;
 
     protected final RedisAccessStrategyFactory accessStrategyFactory = new RedisAccessStrategyFactoryImpl();
 
@@ -77,8 +70,8 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
      */
     protected static Thread expirationThread = null;
 
-    public AbstractRedisRegionFactory(Properties props) {
-        this.props = props;
+    public AbstractRedisRegionFactory(Properties properties) {
+        this.properties = properties;
     }
 
     /**
@@ -99,7 +92,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
         return true;
     }
 
-    protected void createJedisClientAndTimestamper(Settings settings, Properties properties) {
+    protected void initializeRegionFactory(Settings settings, Properties properties) {
         if (redis != null) {
             throw new IllegalStateException("Jedis client already initialized!");
         }

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/AbstractRedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/AbstractRedisRegionFactory.java
@@ -105,6 +105,10 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
         return timestamper.next();
     }
 
+    private Properties loadCacheProperties(Properties properties) {
+        return JedisTool.loadCacheProperties(properties);
+    }
+
     @Override
     public EntityRegion buildEntityRegion(String regionName,
                                           Properties properties,
@@ -115,7 +119,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
                                      regionName,
                                      settings,
                                      metadata,
-                                     JedisTool.loadCacheProperties(properties),
+                                     loadCacheProperties(properties),
                                      timestamper);
     }
 
@@ -129,7 +133,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
                                         regionName,
                                         settings,
                                         metadata,
-                                        JedisTool.loadCacheProperties(properties),
+                                        loadCacheProperties(properties),
                                         timestamper);
     }
 
@@ -143,7 +147,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
                                          regionName,
                                          settings,
                                          metadata,
-                                         JedisTool.loadCacheProperties(properties),
+                                         loadCacheProperties(properties),
                                          timestamper);
     }
 
@@ -154,7 +158,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
         return new RedisQueryResultsRegion(accessStrategyFactory,
                                            redis,
                                            regionName,
-                                           JedisTool.loadCacheProperties(properties),
+                                           loadCacheProperties(properties),
                                            timestamper);
     }
 
@@ -165,7 +169,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
         return new RedisTimestampsRegion(accessStrategyFactory,
                                          redis,
                                          regionName,
-                                         JedisTool.loadCacheProperties(properties),
+                                         loadCacheProperties(properties),
                                          timestamper);
     }
 

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/AbstractRedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/AbstractRedisRegionFactory.java
@@ -46,8 +46,6 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
      */
     protected Settings settings;
 
-    protected Properties properties;
-
     protected final RedisAccessStrategyFactory accessStrategyFactory = new RedisAccessStrategyFactoryImpl();
 
     /**
@@ -69,10 +67,6 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
      * expiration management thread
      */
     protected static Thread expirationThread = null;
-
-    public AbstractRedisRegionFactory(Properties properties) {
-        this.properties = properties;
-    }
 
     /**
      * Whether to optimize for minimals puts or minimal gets.
@@ -121,7 +115,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
                                      regionName,
                                      settings,
                                      metadata,
-                                     properties,
+                                     JedisTool.loadCacheProperties(properties),
                                      timestamper);
     }
 
@@ -135,7 +129,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
                                         regionName,
                                         settings,
                                         metadata,
-                                        properties,
+                                        JedisTool.loadCacheProperties(properties),
                                         timestamper);
     }
 
@@ -149,7 +143,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
                                          regionName,
                                          settings,
                                          metadata,
-                                         properties,
+                                         JedisTool.loadCacheProperties(properties),
                                          timestamper);
     }
 
@@ -160,7 +154,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
         return new RedisQueryResultsRegion(accessStrategyFactory,
                                            redis,
                                            regionName,
-                                           properties,
+                                           JedisTool.loadCacheProperties(properties),
                                            timestamper);
     }
 
@@ -171,7 +165,7 @@ abstract class AbstractRedisRegionFactory implements RegionFactory {
         return new RedisTimestampsRegion(accessStrategyFactory,
                                          redis,
                                          regionName,
-                                         properties,
+                                         JedisTool.loadCacheProperties(properties),
                                          timestamper);
     }
 

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/RedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/RedisRegionFactory.java
@@ -32,8 +32,8 @@ import java.util.Properties;
 @Slf4j
 public class RedisRegionFactory extends AbstractRedisRegionFactory {
 
-    public RedisRegionFactory(Properties props) {
-        super(props);
+    public RedisRegionFactory(Properties properties) {
+        super(properties);
     }
 
     @Override
@@ -41,9 +41,9 @@ public class RedisRegionFactory extends AbstractRedisRegionFactory {
         log.info("Starting RedisRegionFactory...");
 
         this.settings = settings;
-        this.props = JedisTool.loadCacheProperties(properties);
+        this.properties = JedisTool.loadCacheProperties(properties);
         try {
-            createJedisClientAndTimestamper(settings, properties);
+            initializeRegionFactory(settings, this.properties);
             log.info("RedisRegionFactory is started");
         } catch (Exception e) {
             log.error("Fail to start RedisRegionFactory.", e);

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/RedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/RedisRegionFactory.java
@@ -32,18 +32,13 @@ import java.util.Properties;
 @Slf4j
 public class RedisRegionFactory extends AbstractRedisRegionFactory {
 
-    public RedisRegionFactory(Properties properties) {
-        super(properties);
-    }
-
     @Override
     public void start(Settings settings, Properties properties) throws CacheException {
         log.info("Starting RedisRegionFactory...");
 
         this.settings = settings;
-        this.properties = JedisTool.loadCacheProperties(properties);
         try {
-            initializeRegionFactory(settings, this.properties);
+            initializeRegionFactory(settings, JedisTool.loadCacheProperties(properties));
             log.info("RedisRegionFactory is started");
         } catch (Exception e) {
             log.error("Fail to start RedisRegionFactory.", e);

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/SingletonRedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/SingletonRedisRegionFactory.java
@@ -35,19 +35,13 @@ public class SingletonRedisRegionFactory extends AbstractRedisRegionFactory {
 
     private static final AtomicInteger referenceCount = new AtomicInteger();
 
-    public SingletonRedisRegionFactory(Properties properties) {
-        super(properties);
-        log.info("Creating SingletonRedisRegionFactory...");
-    }
-
     @Override
     public synchronized void start(Settings settings, Properties properties) throws CacheException {
         log.info("Starting SingletonRedisRegionFactory...");
 
         this.settings = settings;
-        this.properties = JedisTool.loadCacheProperties(properties);
         try {
-            initializeRegionFactory(settings, this.properties);
+            initializeRegionFactory(settings, JedisTool.loadCacheProperties(properties));
             referenceCount.incrementAndGet();
             log.info("Started SingletonRedisRegionFactory");
         } catch (Exception e) {

--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/SingletonRedisRegionFactory.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/SingletonRedisRegionFactory.java
@@ -33,11 +33,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Slf4j
 public class SingletonRedisRegionFactory extends AbstractRedisRegionFactory {
 
-    private static final AtomicInteger ReferenceCount = new AtomicInteger();
+    private static final AtomicInteger referenceCount = new AtomicInteger();
 
-    public SingletonRedisRegionFactory(Properties props) {
-        super(props);
-        log.info("Creating SingletonRedisRegionFactory instance.");
+    public SingletonRedisRegionFactory(Properties properties) {
+        super(properties);
+        log.info("Creating SingletonRedisRegionFactory...");
     }
 
     @Override
@@ -45,10 +45,10 @@ public class SingletonRedisRegionFactory extends AbstractRedisRegionFactory {
         log.info("Starting SingletonRedisRegionFactory...");
 
         this.settings = settings;
-        this.props = JedisTool.loadCacheProperties(properties);
+        this.properties = JedisTool.loadCacheProperties(properties);
         try {
-            createJedisClientAndTimestamper(settings, properties);
-            ReferenceCount.incrementAndGet();
+            initializeRegionFactory(settings, this.properties);
+            referenceCount.incrementAndGet();
             log.info("Started SingletonRedisRegionFactory");
         } catch (Exception e) {
             throw new CacheException(e);
@@ -59,11 +59,12 @@ public class SingletonRedisRegionFactory extends AbstractRedisRegionFactory {
     public synchronized void stop() {
         log.debug("Stopping SingletonRedisRegionFactory...");
 
-        if (ReferenceCount.decrementAndGet() == 0) {
+        if (referenceCount.decrementAndGet() == 0) {
             try {
                 destroy();
                 log.info("Stopped SingletonRedisRegionFactory");
-            } catch (Exception ignored) { }
+            } catch (Exception ignored) {
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

Region factories must be configurable.

Modifications:

Pass in the correct properties instance when creating region factories.

Result:

Region factories are correctly configured.
