### PR TITLE
Close jedis rather than returnResource. 

### DIFF
--- a/hibernate-redis/src/main/java/org/hibernate/cache/redis/jedis/JedisClient.java
+++ b/hibernate-redis/src/main/java/org/hibernate/cache/redis/jedis/JedisClient.java
@@ -611,7 +611,7 @@ public class JedisClient {
         try {
             return callback.execute(jedis);
         } finally {
-            jedisPool.returnResource(jedis);
+            jedis.close();
         }
     }
 
@@ -629,7 +629,7 @@ public class JedisClient {
             callback.execute(tx);
             return tx.exec();
         } finally {
-            jedisPool.returnResource(jedis);
+            jedis.close();
         }
     }
 
@@ -647,7 +647,7 @@ public class JedisClient {
             // use #sync(), not #exec()
             pipeline.sync();
         } finally {
-            jedisPool.returnResource(jedis);
+            jedis.close();
         }
     }
 


### PR DESCRIPTION
Close handles various error cases where the connection is broken and shouldn't be returned to the pool. 
