### PR TITLE
Update Jedis to pull in most recent 2.8.x fixes

### DIFF
--- a/hibernate-redis/build.gradle
+++ b/hibernate-redis/build.gradle
@@ -22,7 +22,7 @@ dependencies {
         exclude(module: 'jboss-logging')
     }
     compile group: 'org.hibernate', name: 'hibernate-entitymanager', version:hibernateVersion
-    compile group: 'redis.clients', name: 'jedis', version:'2.8.1'
+    compile group: 'redis.clients', name: 'jedis', version:'2.8.2'
     compile group: 'org.xerial.snappy', name: 'snappy-java', version:'1.1.2.1'
     compile group: 'de.ruedigermoeller', name: 'fst', version:'2.45'
     compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.7'


### PR DESCRIPTION
I'm hoping to get a hibernate-redis release version with Jedis 2.8.2. We are hitting an issue in Sentinel mode which is supposedly resolved.

https://github.com/xetorthio/jedis/issues?utf8=%E2%9C%93&q=milestone%3A2.8.2

This is my first PR, so please advise if this should have been approached differently.

Thanks!

Doug
